### PR TITLE
Add a new callPreventDefault property

### DIFF
--- a/src/react-ultimate-pagination.js
+++ b/src/react-ultimate-pagination.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import {getPaginationModel, ITEM_TYPES} from 'ultimate-pagination';
 
-const renderItemComponentFunctionFactory = (itemTypeToComponent, currentPage, onChange) => {
+const renderItemComponentFunctionFactory = (itemTypeToComponent, currentPage, onChange, callPreventDefault) => {
   const onItemClickFunctionFactory = (value) => {
-    return () => {
+    return (event) => {
+      if (callPreventDefault === true) {
+        event.preventDefault()
+      }
       if (onChange && currentPage !== value) {
-        onChange(value);
+        onChange(value, event);
       }
     }
   };
@@ -18,16 +21,17 @@ const renderItemComponentFunctionFactory = (itemTypeToComponent, currentPage, on
 };
 
 export const createUltimatePagination = ({itemTypeToComponent, WrapperComponent = 'div'}) => {
-  const UltimatePaginationComponent = ({currentPage, totalPages, onChange}) => {
+  const UltimatePaginationComponent = ({currentPage, totalPages, onChange, callPreventDefault}) => {
     const paginationModel = getPaginationModel({currentPage, totalPages});
-    const renderItemComponent = renderItemComponentFunctionFactory(itemTypeToComponent, currentPage, onChange);
+    const renderItemComponent = renderItemComponentFunctionFactory(itemTypeToComponent, currentPage, onChange, callPreventDefault);
     return <WrapperComponent>{paginationModel.map(renderItemComponent)}</WrapperComponent>;
   };
 
   UltimatePaginationComponent.propTypes = {
     currentPage: React.PropTypes.number.isRequired,
     totalPages: React.PropTypes.number.isRequired,
-    onChange: React.PropTypes.func
+    onChange: React.PropTypes.func,
+    callPreventDefault: React.Proptypes.bool
   };
 
   return UltimatePaginationComponent;


### PR DESCRIPTION
This is so single page applications may stop UltimatePaginationComponent
from changing the url.

i.e. so the webpage can do that itself using the History apis