### PR TITLE
refactor "PropTypes" for React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/ultimate-pagination/react-ultimate-pagination",
   "dependencies": {
+    "prop-types": "^15.0.0",
     "ultimate-pagination": "1.0.0"
   },
   "peerDependencies": {

--- a/src/react-ultimate-pagination.js
+++ b/src/react-ultimate-pagination.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types'
 import {getPaginationModel, ITEM_TYPES} from 'ultimate-pagination';
 
 const renderItemComponentFunctionFactory = (itemTypeToComponent, currentPage, onChange) => {
@@ -44,14 +45,14 @@ export const createUltimatePagination = ({itemTypeToComponent, WrapperComponent 
   };
 
   UltimatePaginationComponent.propTypes = {
-    currentPage: React.PropTypes.number.isRequired,
-    totalPages: React.PropTypes.number.isRequired,
-    boundaryPagesRange: React.PropTypes.number,
-    siblingPagesRange: React.PropTypes.number,
-    hideEllipsis: React.PropTypes.bool,
-    hidePreviousAndNextPageLinks: React.PropTypes.bool,
-    hideFirstAndLastPageLinks: React.PropTypes.bool,
-    onChange: React.PropTypes.func
+    currentPage: PropTypes.number.isRequired,
+    totalPages: PropTypes.number.isRequired,
+    boundaryPagesRange: PropTypes.number,
+    siblingPagesRange: PropTypes.number,
+    hideEllipsis: PropTypes.bool,
+    hidePreviousAndNextPageLinks: PropTypes.bool,
+    hideFirstAndLastPageLinks: PropTypes.bool,
+    onChange: PropTypes.func
   };
 
   return UltimatePaginationComponent;


### PR DESCRIPTION
In order to suppress warnings in React 15, "PropTypes" must be used using "prop-types" package.