### PR TITLE
Update React peer dependencies to support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "ultimate-pagination": "1.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",


### PR DESCRIPTION
## Why?
When using `react-ultimate-pagination` with React 16, a peer dependency warning shows up from NPM/Yarn.

## What changed?
- Upped the peer dependencies for `react` and `react-dom` to also allow version 16

Fixes #9